### PR TITLE
Spocan 59 | Ajustes en RestPerformer para respetar convenciones de JWT del backend

### DIFF
--- a/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
@@ -7,8 +7,10 @@ import okhttp3.Request;
 import okhttp3.RequestBody;
 
 public class RestPerformer {
-    private static final String USER_TOKEN_HEADER = "User-Token";
-    private static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; charset=utf-8";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String CHARSET_UTF_8 = "charset=utf-8";
+    private static final String APPLICATION_JSON_CHARSET_UTF_8 = "application/json; " + CHARSET_UTF_8;
+    private static final String TEXT_PLAIN_CHARSET_UTF_8 = "text/plain; " + CHARSET_UTF_8;
 
     private final OkHttpClient httpClient;
     private final String jwt;
@@ -25,7 +27,12 @@ public class RestPerformer {
     }
 
     public void post(String url, String payload, Callback serverCallback) {
-        Request request = buildPostRequest(url, payload);
+        Request request = buildPostRequestJson(url, payload);
+        perform(request, serverCallback);
+    }
+
+    public void postText(String url, String payload, Callback serverCallback) {
+        Request request = buildPostRequestJson(url, payload);
         perform(request, serverCallback);
     }
 
@@ -34,18 +41,30 @@ public class RestPerformer {
     }
 
     private Request buildGetRequest(String url) {
-        return new Request.Builder()
-                .url(url)
+        return commonRequestBuilder(url)
                 .get()
-                .addHeader(USER_TOKEN_HEADER, jwt)
                 .build();
     }
 
-    private Request buildPostRequest(String url, String payload) {
+    private Request buildPostRequestJson(String url, String payload) {
+        return commonRequestBuilder(url)
+                .post(RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF_8), payload))
+                .build();
+    }
+
+    private Request buildPostRequestText(String url, String payload) {
+        return buildPostRequest(url, payload, MediaType.parse(TEXT_PLAIN_CHARSET_UTF_8));
+    }
+
+    private Request buildPostRequest(String url, String payload, MediaType mediaType) {
+        return commonRequestBuilder(url)
+                .post(RequestBody.create(mediaType, payload))
+                .build();
+    }
+
+    private Request.Builder commonRequestBuilder(String url) {
         return new Request.Builder()
                 .url(url)
-                .post(RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF_8), payload))
-                .addHeader(USER_TOKEN_HEADER, jwt)
-                .build();
+                .addHeader(AUTHORIZATION_HEADER, "Bearer " + jwt);
     }
 }

--- a/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
@@ -14,11 +14,22 @@ public class RestPerformer {
 
     private final OkHttpClient httpClient;
     private final String jwt;
+    private final boolean authorizable;
 
 
     public RestPerformer(String jwt) {
+        this(jwt, true);
+    }
+
+    private RestPerformer(String jwt, boolean authorizable) {
         this.jwt = jwt;
         this.httpClient = new OkHttpClient();
+        this.authorizable = authorizable;
+    }
+
+    public static void postTextUnauthorizable(String url, String payload, Callback serverCallback) {
+        RestPerformer performer = new RestPerformer(null, false);
+        performer.postText(url, payload, serverCallback);
     }
 
     public void get(String url, Callback serverCallback) {
@@ -61,8 +72,12 @@ public class RestPerformer {
     }
 
     private Request.Builder commonRequestBuilder(String url) {
-        return new Request.Builder()
-                .url(url)
-                .addHeader(AUTHORIZATION_HEADER, "Bearer " + jwt);
+        Request.Builder builder = new Request.Builder().url(url);
+
+        if (this.authorizable) {
+            builder.addHeader(AUTHORIZATION_HEADER, "Bearer " + jwt);
+        }
+
+        return builder;
     }
 }

--- a/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
@@ -47,9 +47,7 @@ public class RestPerformer {
     }
 
     private Request buildPostRequestJson(String url, String payload) {
-        return commonRequestBuilder(url)
-                .post(RequestBody.create(MediaType.parse(APPLICATION_JSON_CHARSET_UTF_8), payload))
-                .build();
+        return buildPostRequest(url, payload, MediaType.parse(APPLICATION_JSON_CHARSET_UTF_8));
     }
 
     private Request buildPostRequestText(String url, String payload) {

--- a/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/callback/rest/RestPerformer.java
@@ -43,7 +43,7 @@ public class RestPerformer {
     }
 
     public void postText(String url, String payload, Callback serverCallback) {
-        Request request = buildPostRequestJson(url, payload);
+        Request request = buildPostRequestText(url, payload);
         perform(request, serverCallback);
     }
 

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
@@ -24,10 +24,8 @@ public class RestClientBackend implements Backend {
         this.performer = new RestPerformer(jwt);
     }
 
-    //POST
     public static void doAuthenticate(String firebaseToken, CallbackInstance<User> callback) {
-        RestPerformer testRestPerformer = new RestPerformer(" testToken");
-        testRestPerformer.post(Paths.BASE_TEST + Paths.AUTHENTICATE, firebaseToken, new ServerEnsureResponseCallback() {
+        RestPerformer.postTextUnauthorizable(Paths.BASE + Paths.AUTHENTICATE, firebaseToken, new ServerEnsureResponseCallback() {
             @Override
             void doSuccess(@NotNull String serverResponse) {
                 TokenInfo tokenInfo = TokenInfo.convertJson(serverResponse);


### PR DESCRIPTION
- Ajustes en RestPerformer para respetar las convenciones de Header de autorización establecidas en el backend (misma tarjeta). 
- Se cambia el nombre y valor del Header de autorización y se agrega el sufijo "Bearer " al jwt enviado. Eso es lo que espera el backend.
- Se agrega servicio de llamada estática al backend sin contemplar el jwt. Se utiliza en el doAuthorize()
- Se agregar posibilidad de postear texto plano y json (el doAuthorize() postea texto plano).


