### PR TITLE
SPOCAN-52 | Traer iniciativas por batches

### DIFF
--- a/app/src/main/java/com/neiapp/spocan/backend/Backend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/Backend.java
@@ -8,10 +8,12 @@ import com.neiapp.spocan.backend.callback.CallbackInstance;
 import com.neiapp.spocan.backend.callback.CallbackVoid;
 import com.neiapp.spocan.backend.rest.RestClientBackend;
 
+import java.time.LocalDateTime;
+
 public interface Backend {
 
     void createInitiative(Initiative initiative, CallbackVoid callback);
-    void getAllInitiatives(CallbackCollection<Initiative> collection);
+    void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, int offset, CallbackCollection<Initiative> collection);
     void getUser(CallbackInstance<User> callback);
     void logOut(CallbackVoid callback);
     void createUser(User user, CallbackInstance<User> callbackUser);

--- a/app/src/main/java/com/neiapp/spocan/backend/Backend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/Backend.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 public interface Backend {
 
     void createInitiative(Initiative initiative, CallbackVoid callback);
-    void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, int offset, CallbackCollection<Initiative> collection);
+    void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, CallbackCollection<Initiative> collection);
     void getUser(CallbackInstance<User> callback);
     void logOut(CallbackVoid callback);
     void createUser(User user, CallbackInstance<User> callbackUser);

--- a/app/src/main/java/com/neiapp/spocan/backend/Backend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/Backend.java
@@ -1,8 +1,8 @@
 package com.neiapp.spocan.backend;
 
 import com.neiapp.spocan.BuildConfig;
-import com.neiapp.spocan.Models.Initiative;
-import com.neiapp.spocan.Models.User;
+import com.neiapp.spocan.models.Initiative;
+import com.neiapp.spocan.models.User;
 import com.neiapp.spocan.backend.callback.CallbackCollection;
 import com.neiapp.spocan.backend.callback.CallbackInstance;
 import com.neiapp.spocan.backend.callback.CallbackVoid;

--- a/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
@@ -19,10 +19,10 @@ public class MockedBackend implements Backend {
     protected MockedBackend() {
         if (initiative_store == null) {
             initiative_store = new ArrayList<>();
-            initiative_store.add(new Initiative("1", "[test] Iniciativa de prueba 1", MockedImagesBase64.RED_800_X_600, "TestUser-1", "2021-04-27T22:59:34", false));
-            initiative_store.add(new Initiative("2", "[test] Iniciativa de prueba 2. Esta vez la descripcion es un poco mas larga.", MockedImagesBase64.BLUE_800_X_600, "TestUser-2", "2021-04-22T14:13:05", false));
-            initiative_store.add(new Initiative("3", "[test] Iniciativa de prueba 3", MockedImagesBase64.GREEN_800_X_600, "CurrentUser", "2021-03-16T18:07:14", true));
-            initiative_store.add(new Initiative("4", "[test] Iniciativa de prueba 4", MockedImagesBase64.YELLOW_800_X_600, "TestUser-1", "2020-09-11T11:42:35", false));
+            initiative_store.add(new Initiative("1", "[test] Iniciativa de prueba 1", MockedImagesBase64.RED_800_X_600, "TestUser-1", "2021-04-27T22:59:34"));
+            initiative_store.add(new Initiative("2", "[test] Iniciativa de prueba 2. Esta vez la descripcion es un poco mas larga.", MockedImagesBase64.BLUE_800_X_600, "TestUser-2", "2021-04-22T14:13:05"));
+            initiative_store.add(new Initiative("3", "[test] Iniciativa de prueba 3", MockedImagesBase64.GREEN_800_X_600, "CurrentUser", "2021-03-16T18:07:14"));
+            initiative_store.add(new Initiative("4", "[test] Iniciativa de prueba 4", MockedImagesBase64.YELLOW_800_X_600, "TestUser-1", "2020-09-11T11:42:35"));
         }
     }
 

--- a/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
@@ -1,8 +1,8 @@
 package com.neiapp.spocan.backend;
 
-import com.neiapp.spocan.Models.Initiative;
-import com.neiapp.spocan.Models.User;
-import com.neiapp.spocan.Models.UserType;
+import com.neiapp.spocan.models.Initiative;
+import com.neiapp.spocan.models.User;
+import com.neiapp.spocan.models.UserType;
 import com.neiapp.spocan.backend.callback.CallbackCollection;
 import com.neiapp.spocan.backend.callback.CallbackInstance;
 import com.neiapp.spocan.backend.callback.CallbackVoid;

--- a/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
@@ -41,7 +41,7 @@ public class MockedBackend implements Backend {
     }
 
     @Override
-    public void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, int offset, CallbackCollection<Initiative> collection) {
+    public void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, CallbackCollection<Initiative> collection) {
         collection.onSuccess(initiative_store);
     }
 

--- a/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/MockedBackend.java
@@ -8,6 +8,7 @@ import com.neiapp.spocan.backend.callback.CallbackInstance;
 import com.neiapp.spocan.backend.callback.CallbackVoid;
 
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 public class MockedBackend implements Backend {
@@ -40,7 +41,7 @@ public class MockedBackend implements Backend {
     }
 
     @Override
-    public void getAllInitiatives(CallbackCollection<Initiative> collection) {
+    public void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, int offset, CallbackCollection<Initiative> collection) {
         collection.onSuccess(initiative_store);
     }
 

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
@@ -3,13 +3,13 @@ package com.neiapp.spocan.backend.rest;
 public class Paths {
 
     // PROD
-    // public static final String BASE = "https://spochi.herokuapp.com";
+    public static final String BASE = "https://spochi.herokuapp.com";
 
     // TEST
     //public static final String BASE = "https://spochi-test.herokuapp.com";
 
     // LOCAL
-    public static final String BASE = "http://10.0.2.2:8080";
+    // public static final String BASE = "http://10.0.2.2:8080";
 
     // Authenticate
     public static final String AUTHENTICATE = "/authenticate";

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
@@ -9,7 +9,7 @@ public class Paths {
     //public static final String BASE = "https://spochi-test.herokuapp.com";
 
     // LOCAL
-    //public static final String BASE = "http://10.0.2.2:8080";
+    // public static final String BASE = "http://10.0.2.2:8080";
 
     // Authenticate
     public static final String AUTHENTICATE = "/authenticate";

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
@@ -3,13 +3,13 @@ package com.neiapp.spocan.backend.rest;
 public class Paths {
 
     // PROD
-    public static final String BASE = "https://spochi.herokuapp.com";
+    // public static final String BASE = "https://spochi.herokuapp.com";
 
     // TEST
     //public static final String BASE = "https://spochi-test.herokuapp.com";
 
     // LOCAL
-    // public static final String BASE = "http://10.0.2.2:8080";
+    public static final String BASE = "http://10.0.2.2:8080";
 
     // Authenticate
     public static final String AUTHENTICATE = "/authenticate";

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/Paths.java
@@ -9,7 +9,7 @@ public class Paths {
     //public static final String BASE = "https://spochi-test.herokuapp.com";
 
     // LOCAL
-    // public static final String BASE = "http://10.0.2.2:8080";
+    //public static final String BASE = "http://10.0.2.2:8080";
 
     // Authenticate
     public static final String AUTHENTICATE = "/authenticate";

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
@@ -2,9 +2,10 @@ package com.neiapp.spocan.backend.rest;
 
 import androidx.annotation.Nullable;
 
-import com.neiapp.spocan.Models.Initiative;
-import com.neiapp.spocan.Models.TokenInfo;
-import com.neiapp.spocan.Models.User;
+import com.neiapp.spocan.models.Initiative;
+import com.neiapp.spocan.models.InitiativeStatus;
+import com.neiapp.spocan.models.TokenInfo;
+import com.neiapp.spocan.models.User;
 import com.neiapp.spocan.backend.Backend;
 import com.neiapp.spocan.backend.ParseJsonException;
 import com.neiapp.spocan.backend.callback.CallbackCollection;
@@ -110,11 +111,12 @@ public class RestClientBackend implements Backend {
         queryParamsBuilder
                 .withParam(QueryParam.ORDER, "1")
                 .withParam(QueryParam.LIMIT, "2")
-                .withParam(QueryParam.STATUS, "2");
+                .withParam(QueryParam.STATUS, String.valueOf(InitiativeStatus.APPROVED.getId()));
+
         if (fromCurrentUser) {
                 queryParamsBuilder.withParam(QueryParam.CURRENT_USER, String.valueOf(fromCurrentUser));
                 queryParamsBuilder.withParam(QueryParam.OFFSET, String.valueOf(offset));
-                queryParamsBuilder.withParam(QueryParam.STATUS, "1"); // sumamos las pendientes
+                queryParamsBuilder.withParam(QueryParam.STATUS, String.valueOf(InitiativeStatus.PENDING.getId())); // sumamos las pendientes
 
         }
 

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
@@ -106,7 +106,7 @@ public class RestClientBackend implements Backend {
 
 
     @Override
-    public void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, int offset, CallbackCollection<Initiative> callback) {
+    public void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, CallbackCollection<Initiative> callback) {
         QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
         queryParamsBuilder
                 .withParam(QueryParam.ORDER, "1")
@@ -115,7 +115,6 @@ public class RestClientBackend implements Backend {
 
         if (fromCurrentUser) {
                 queryParamsBuilder.withParam(QueryParam.CURRENT_USER, String.valueOf(fromCurrentUser));
-                queryParamsBuilder.withParam(QueryParam.OFFSET, String.valueOf(offset));
                 queryParamsBuilder.withParam(QueryParam.STATUS, String.valueOf(InitiativeStatus.PENDING.getId())); // sumamos las pendientes
 
         }

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
@@ -16,7 +16,7 @@ import com.neiapp.spocan.backend.rest.query.QueryParamsBuilder;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Map;
+import java.time.LocalDateTime;
 
 import static com.neiapp.spocan.backend.rest.HTTPCodes.ERROR_PARSE_JSON;
 
@@ -105,10 +105,24 @@ public class RestClientBackend implements Backend {
 
 
     @Override
-    public void getAllInitiatives(CallbackCollection<Initiative> callback) {
-        Map<String, String> queryParams = new QueryParamsBuilder().withParam(QueryParam.ORDER, "1").build();
+    public void getAllInitiatives(LocalDateTime dateTop, boolean fromCurrentUser, int offset, CallbackCollection<Initiative> callback) {
+        QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder();
+        queryParamsBuilder
+                .withParam(QueryParam.ORDER, "1")
+                .withParam(QueryParam.LIMIT, "2")
+                .withParam(QueryParam.STATUS, "2");
+        if (fromCurrentUser) {
+                queryParamsBuilder.withParam(QueryParam.CURRENT_USER, String.valueOf(fromCurrentUser));
+                queryParamsBuilder.withParam(QueryParam.OFFSET, String.valueOf(offset));
+                queryParamsBuilder.withParam(QueryParam.STATUS, "1"); // sumamos las pendientes
 
-        performer.get(Paths.BASE + Paths.INITIATIVE + Paths.ALL, queryParams, new ServerEnsureResponseCallback() {
+        }
+
+        if (dateTop != null) {
+               queryParamsBuilder.withParam(QueryParam.DATE_TOP, dateTop.toString());
+        }
+
+        performer.get(Paths.BASE + Paths.INITIATIVE + Paths.ALL, queryParamsBuilder.build(), new ServerEnsureResponseCallback() {
             @Override
             void doSuccess(@NotNull String serverResponse) {
                 executeJsonAction(() -> callback.onSuccess(Initiative.convertJsonList(serverResponse)), callback);

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/RestClientBackend.java
@@ -114,7 +114,7 @@ public class RestClientBackend implements Backend {
                 .withParam(QueryParam.STATUS, String.valueOf(InitiativeStatus.APPROVED.getId()));
 
         if (fromCurrentUser) {
-                queryParamsBuilder.withParam(QueryParam.CURRENT_USER, String.valueOf(fromCurrentUser));
+                queryParamsBuilder.withParam(QueryParam.CURRENT_USER, Boolean.toString(true));
                 queryParamsBuilder.withParam(QueryParam.STATUS, String.valueOf(InitiativeStatus.PENDING.getId())); // sumamos las pendientes
 
         }

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/RestPerformer.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/RestPerformer.java
@@ -1,6 +1,7 @@
 package com.neiapp.spocan.backend.rest;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -51,7 +52,7 @@ public class RestPerformer {
         get(url, Collections.emptyMap(), serverCallback);
     }
 
-    public void get(String url, Map<String, String> queryParams, Callback serverCallback) {
+    public void get(String url, Map<String, List<String>> queryParams, Callback serverCallback) {
         Request request = buildGetRequest(url, queryParams);
         perform(request, serverCallback);
     }
@@ -70,7 +71,7 @@ public class RestPerformer {
         httpClient.newCall(request).enqueue(serverCallback);
     }
 
-    private Request buildGetRequest(String url, Map<String, String> queryParams) {
+    private Request buildGetRequest(String url, Map<String, List<String>> queryParams) {
         return commonRequestBuilder(url, queryParams)
                 .get()
                 .build();
@@ -94,9 +95,9 @@ public class RestPerformer {
         return commonRequestBuilder(url, Collections.emptyMap());
     }
 
-    private Request.Builder commonRequestBuilder(String url, Map<String, String> queryParams) {
+    private Request.Builder commonRequestBuilder(String url, Map<String, List<String>> queryParams) {
         final HttpUrl.Builder httpBuilder = HttpUrl.parse(url).newBuilder();
-        queryParams.forEach(httpBuilder::addQueryParameter);
+        queryParams.forEach((key, values) -> values.forEach(value -> httpBuilder.addQueryParameter(key, value)));
 
         final Request.Builder builder = new Request.Builder().url(httpBuilder.build());
         builder.addHeader(CLIENT_ID,ANDROID_ID);

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/query/QueryParam.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/query/QueryParam.java
@@ -1,7 +1,12 @@
 package com.neiapp.spocan.backend.rest.query;
 
 public enum QueryParam {
-    ORDER("order");
+    ORDER("order"),
+    STATUS("statusId"),
+    CURRENT_USER("currentUser"),
+    DATE_TOP("dateTop"),
+    OFFSET("offset"),
+    LIMIT("limit");
 
     private final String label;
 

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/query/QueryParam.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/query/QueryParam.java
@@ -5,7 +5,6 @@ public enum QueryParam {
     STATUS("statusId"),
     CURRENT_USER("currentUser"),
     DATE_TOP("dateTop"),
-    OFFSET("offset"),
     LIMIT("limit");
 
     private final String label;

--- a/app/src/main/java/com/neiapp/spocan/backend/rest/query/QueryParamsBuilder.java
+++ b/app/src/main/java/com/neiapp/spocan/backend/rest/query/QueryParamsBuilder.java
@@ -1,21 +1,23 @@
 package com.neiapp.spocan.backend.rest.query;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class QueryParamsBuilder {
-    final Map<String, String> queryParams;
+    final Map<String, List<String>> queryParams;
 
     public QueryParamsBuilder() {
         this.queryParams = new HashMap<>();
     }
 
     public QueryParamsBuilder withParam(QueryParam queryParam, String value) {
-        this.queryParams.put(queryParam.getLabel(), value);
+        this.queryParams.computeIfAbsent(queryParam.getLabel(), k -> new ArrayList<>()).add(value);
         return this;
     }
 
-    public Map<String, String> build() {
+    public Map<String, List<String>> build() {
         return queryParams;
     }
 }

--- a/app/src/main/java/com/neiapp/spocan/models/Initiative.java
+++ b/app/src/main/java/com/neiapp/spocan/models/Initiative.java
@@ -1,4 +1,4 @@
-package com.neiapp.spocan.Models;
+package com.neiapp.spocan.models;
 
 import android.graphics.Bitmap;
 import android.os.Build;

--- a/app/src/main/java/com/neiapp/spocan/models/Initiative.java
+++ b/app/src/main/java/com/neiapp/spocan/models/Initiative.java
@@ -106,7 +106,7 @@ public class Initiative {
 
             return json.toString();
         }catch (Exception e){
-            String message = "failed to convert initiative to json"+e.getMessage();
+            String message = "failed to convert initiative to json: " + e.getMessage();
             System.out.println(message);
             throw new ParseJsonException(message);
 
@@ -125,7 +125,7 @@ public class Initiative {
 
             return new Initiative(_id, description, image, nickname, date);
         } catch (Exception e) {
-            String message = "failed to convert jsno to initiative"+e.getMessage();
+            String message = "failed to convert jsno to initiative: " + e.getMessage();
             System.out.println(message);
             throw new ParseJsonException(message);
         }

--- a/app/src/main/java/com/neiapp/spocan/models/Initiative.java
+++ b/app/src/main/java/com/neiapp/spocan/models/Initiative.java
@@ -27,30 +27,26 @@ public class Initiative {
     private String image;
     private String nickname;
     private LocalDateTime date;
-    private boolean isFromCurrentUser;
 
-    public Initiative(String _id, String description, String image, String nickname, String dateStrUTC, boolean isFromCurrentUser) {
+    public Initiative(String _id, String description, String image, String nickname, String dateStrUTC) {
         this._id = _id;
         this.description = description;
         this.image = image;
         this.nickname = nickname;
-        this.isFromCurrentUser = isFromCurrentUser;
         setDate(dateStrUTC);
     }
 
-    public Initiative(String description, String image, boolean isFromCurrentUser) {
+    public Initiative(String description, String image) {
         this.description = description;
         this.image = image;
-        this.isFromCurrentUser = isFromCurrentUser;
         this._id = null;
         this.nickname = null;
         initDate();
     }
 
-    public Initiative(String description, Bitmap bitmap, boolean isFromCurrentUser) {
+    public Initiative(String description, Bitmap bitmap) {
         this.description = description;
         setImage(bitmap);
-        this.isFromCurrentUser = isFromCurrentUser;
         this._id = null;
         this.nickname = null;
         initDate();
@@ -78,10 +74,6 @@ public class Initiative {
 
     public String getNickname() {
         return nickname;
-    }
-
-    public boolean isFromCurrentUser() {
-        return isFromCurrentUser;
     }
 
     public void setId(String id) {
@@ -124,20 +116,14 @@ public class Initiative {
     public static Initiative convertJson(String jsonToTransform) throws ParseJsonException {
         try {
             JSONObject jsonObject = new JSONObject(jsonToTransform);
+
             final String _id = jsonObject.getString("_id");
             final String description = jsonObject.getString("description");
             final String image = jsonObject.getString("image");
             final String nickname = jsonObject.getString("nickname");
             final String date = jsonObject.getString("date");
 
-            final boolean isFromCurrentUser;
-            if (jsonObject.has("from_current_user")) {
-                isFromCurrentUser = jsonObject.getBoolean("from_current_user");
-            } else {
-                isFromCurrentUser = false;
-            }
-
-            return new Initiative(_id, description, image, nickname, date, isFromCurrentUser);
+            return new Initiative(_id, description, image, nickname, date);
         } catch (Exception e) {
             String message = "failed to convert jsno to initiative"+e.getMessage();
             System.out.println(message);

--- a/app/src/main/java/com/neiapp/spocan/models/InitiativeStatus.java
+++ b/app/src/main/java/com/neiapp/spocan/models/InitiativeStatus.java
@@ -1,0 +1,32 @@
+package com.neiapp.spocan.models;
+
+import java.util.Arrays;
+
+public enum InitiativeStatus {
+    PENDING(1),
+    APPROVED(2),
+    REJECTED(3);
+
+    private final int id;
+
+    InitiativeStatus(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public static InitiativeStatus fromIdOrElseThrow(int id) {
+        return Arrays.stream(values())
+                .filter(v -> v.id == id)
+                .findFirst()
+                .orElseThrow(() -> new InitiativeStatusNotFoundException(id));
+    }
+
+    public static class InitiativeStatusNotFoundException extends RuntimeException {
+        private InitiativeStatusNotFoundException(int id) {
+            super(String.format("No InitiativeStatus with id [%s] present", id));
+        }
+    }
+}

--- a/app/src/main/java/com/neiapp/spocan/models/TokenInfo.java
+++ b/app/src/main/java/com/neiapp/spocan/models/TokenInfo.java
@@ -1,8 +1,7 @@
-package com.neiapp.spocan.Models;
+package com.neiapp.spocan.models;
 
 import com.neiapp.spocan.backend.ParseJsonException;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 public class TokenInfo {

--- a/app/src/main/java/com/neiapp/spocan/models/User.java
+++ b/app/src/main/java/com/neiapp/spocan/models/User.java
@@ -1,4 +1,4 @@
-package com.neiapp.spocan.Models;
+package com.neiapp.spocan.models;
 
 import com.google.gson.JsonObject;
 import com.neiapp.spocan.backend.ParseJsonException;

--- a/app/src/main/java/com/neiapp/spocan/models/UserType.java
+++ b/app/src/main/java/com/neiapp/spocan/models/UserType.java
@@ -1,4 +1,4 @@
-package com.neiapp.spocan.Models;
+package com.neiapp.spocan.models;
 
 import java.util.Arrays;
 

--- a/app/src/main/java/com/neiapp/spocan/ui/activity/InitiativeActivity.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/activity/InitiativeActivity.java
@@ -16,7 +16,7 @@ import android.widget.Toast;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 
-import com.neiapp.spocan.Models.Initiative;
+import com.neiapp.spocan.models.Initiative;
 import com.neiapp.spocan.R;
 import com.neiapp.spocan.backend.Backend;
 import com.neiapp.spocan.backend.callback.CallbackVoid;

--- a/app/src/main/java/com/neiapp/spocan/ui/activity/InitiativeActivity.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/activity/InitiativeActivity.java
@@ -74,7 +74,7 @@ public class InitiativeActivity extends SpocanActivity {
 
                 if (validateField()) {
                     spinnerDialog.start();
-                    Initiative intitiative = new Initiative(textDescription.getText().toString(), bitmap, true);
+                    Initiative intitiative = new Initiative(textDescription.getText().toString(), bitmap);
                     Backend backend = Backend.getInstance();
                     backend.createInitiative(intitiative, new CallbackVoid() {
                         @Override

--- a/app/src/main/java/com/neiapp/spocan/ui/activity/LoginActivity.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/activity/LoginActivity.java
@@ -24,7 +24,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.GetTokenResult;
 import com.google.firebase.auth.GoogleAuthProvider;
-import com.neiapp.spocan.Models.User;
+import com.neiapp.spocan.models.User;
 import com.neiapp.spocan.R;
 import com.neiapp.spocan.backend.Backend;
 import com.neiapp.spocan.backend.callback.CallbackInstance;

--- a/app/src/main/java/com/neiapp/spocan/ui/activity/RegisterUserActivity.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/activity/RegisterUserActivity.java
@@ -1,6 +1,5 @@
 package com.neiapp.spocan.ui.activity;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.TextUtils;
@@ -13,8 +12,8 @@ import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 
-import com.neiapp.spocan.Models.User;
-import com.neiapp.spocan.Models.UserType;
+import com.neiapp.spocan.models.User;
+import com.neiapp.spocan.models.UserType;
 import com.neiapp.spocan.R;
 import com.neiapp.spocan.backend.Backend;
 import com.neiapp.spocan.backend.callback.CallbackInstance;

--- a/app/src/main/java/com/neiapp/spocan/ui/extra/SpinnerDialog.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/extra/SpinnerDialog.java
@@ -2,6 +2,8 @@ package com.neiapp.spocan.ui.extra;
 
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
@@ -14,10 +16,14 @@ public class SpinnerDialog {
     private final AlertDialog dialog;
 
     public SpinnerDialog(@NotNull final Activity activity) {
-        this(activity, "Cargando"); // default message
+        this(activity, "Cargando", false); // default message
     }
 
     public SpinnerDialog(@NotNull final Activity activity, @NotNull final String loadingMessage) {
+        this(activity, loadingMessage, false); // default message
+    }
+
+    public SpinnerDialog(@NotNull final Activity activity, @NotNull final String loadingMessage, boolean transparent) {
         final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         final LayoutInflater inflater = activity.getLayoutInflater();
         final View inflatedView = inflater.inflate(R.layout.spinner_dialog, null);
@@ -26,6 +32,10 @@ public class SpinnerDialog {
         builder.setView(inflatedView);
         builder.setCancelable(false);
         dialog = builder.create();
+
+        if (transparent) {
+            dialog.getWindow().setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+        }
     }
 
     public void start() {

--- a/app/src/main/java/com/neiapp/spocan/ui/extra/SpinnerDialog.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/extra/SpinnerDialog.java
@@ -15,12 +15,8 @@ import org.jetbrains.annotations.NotNull;
 public class SpinnerDialog {
     private final AlertDialog dialog;
 
-    public SpinnerDialog(@NotNull final Activity activity) {
-        this(activity, "Cargando", false); // default message
-    }
-
     public SpinnerDialog(@NotNull final Activity activity, @NotNull final String loadingMessage) {
-        this(activity, loadingMessage, false); // default message
+        this(activity, loadingMessage, false);
     }
 
     public SpinnerDialog(@NotNull final Activity activity, @NotNull final String loadingMessage, boolean transparent) {

--- a/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
@@ -59,7 +59,7 @@ public class HomeFragment extends Fragment {
         nestedScrollView.setOnScrollChangeListener(new NestedScrollView.OnScrollChangeListener() {
            @Override
            public void onScrollChange(NestedScrollView scrollView, int scrollX, int actualY, int oldScrollX, int oldScrollY) {
-               if (bottomWasReached(scrollView)) {
+               if (!HomeFragment.this.initiatives.isEmpty() && bottomWasReached(scrollView)) {
                    fetchInitiatives();
                }
            }

--- a/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
@@ -3,6 +3,7 @@ package com.neiapp.spocan.ui.fragment;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,6 +12,7 @@ import android.widget.LinearLayout;
 import android.widget.Switch;
 import android.widget.TextView;
 
+import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -22,6 +24,7 @@ import com.neiapp.spocan.ui.activity.InitiativeActivity;
 import com.neiapp.spocan.ui.activity.SpocanActivity;
 import com.neiapp.spocan.ui.extra.SpinnerDialog;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -32,6 +35,7 @@ public class HomeFragment extends Fragment {
     LinearLayout mparent;
     LayoutInflater layoutInflater;
     List<Initiative> initiatives;
+    NestedScrollView nestedScrollView;
 
 
     @Override
@@ -50,7 +54,26 @@ public class HomeFragment extends Fragment {
         layoutInflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         initiatives = new ArrayList<>();
 
-        fetchInitiatives();
+        nestedScrollView = root.findViewById(R.id.scrollView);
+        nestedScrollView.setOnScrollChangeListener(new NestedScrollView.OnScrollChangeListener() {
+           @Override
+           public void onScrollChange(NestedScrollView view, int scrollX, int actualY, int oldScrollX, int oldScrollY) {
+               if (bottomWasReached(view, actualY)) {
+                   final SpinnerDialog spinnerDialog = new SpinnerDialog(getActivity(), "Cargando más iniciativas...");
+                   spinnerDialog.start();
+                   Handler handler = new Handler();
+                   handler.postDelayed(spinnerDialog::stop, 5000);
+               }
+           }
+
+           private boolean bottomWasReached(NestedScrollView view, int actualY) {
+               final int bottomY = Math.abs(view.getMeasuredHeight() - view.getChildAt(0).getMeasuredHeight());
+               return  bottomY - actualY == 0;
+           }
+
+       });
+
+                fetchInitiatives();
 
         //publicar
         post = root.findViewById(R.id.CrearPost);
@@ -139,6 +162,10 @@ public class HomeFragment extends Fragment {
                 populatePostItemsWithEveryInitiative();
             }
         }
+    }
+
+    private LocalDateTime getLastInitiativeDateUTC() {
+        return initiatives.isEmpty() ? null : initiatives.get(initiatives.size()).getDateUTC();
     }
 }
 

--- a/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
@@ -15,7 +15,7 @@ import androidx.core.widget.NestedScrollView;
 import androidx.fragment.app.Fragment;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.neiapp.spocan.Models.Initiative;
+import com.neiapp.spocan.models.Initiative;
 import com.neiapp.spocan.R;
 import com.neiapp.spocan.backend.Backend;
 import com.neiapp.spocan.backend.callback.CallbackCollection;
@@ -26,7 +26,6 @@ import com.neiapp.spocan.ui.extra.SpinnerDialog;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Predicate;
 
 public class HomeFragment extends Fragment {
 
@@ -71,7 +70,8 @@ public class HomeFragment extends Fragment {
 
            private boolean bottomWasReached(NestedScrollView view, int actualY) {
                final int bottomY = Math.abs(view.getMeasuredHeight() - view.getChildAt(0).getMeasuredHeight());
-               return  bottomY - actualY == 0;
+               // System.out.println(bottomY - actualY);
+               return bottomY - actualY == -110; // todo mejorar esto
            }
 
        });

--- a/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/fragment/HomeFragment.java
@@ -34,7 +34,11 @@ public class HomeFragment extends Fragment {
     LayoutInflater layoutInflater;
     List<Initiative> initiatives;
     NestedScrollView nestedScrollView;
+
+    // exclusivo para el scroll en modo currentUser,
+    // ya que al ser una consulta por clave foránea no aplican los filtros de Fiware
     int offset;
+
     boolean fromCurrentUser = false;
 
 
@@ -60,17 +64,17 @@ public class HomeFragment extends Fragment {
            @Override
            public void onScrollChange(NestedScrollView view, int scrollX, int actualY, int oldScrollX, int oldScrollY) {
                if (bottomWasReached(view, actualY)) {
-                   if (fromCurrentUser) {
-                       offset = initiatives.size();
-                   }
-                   fetchInitiatives();
 
+                   if (fromCurrentUser) {
+                       offset = initiatives.size(); // salteo la cantidad que tengo en la lista
+                   }
+
+                   fetchInitiatives();
                }
            }
 
            private boolean bottomWasReached(NestedScrollView view, int actualY) {
                final int bottomY = Math.abs(view.getMeasuredHeight() - view.getChildAt(0).getMeasuredHeight());
-               // System.out.println(bottomY - actualY);
                return bottomY - actualY == -110; // todo mejorar esto
            }
 
@@ -95,12 +99,13 @@ public class HomeFragment extends Fragment {
     private void fetchInitiatives() {
         final SpinnerDialog spinnerDialog = new SpinnerDialog(getActivity(), "", true);
         spinnerDialog.start();
-        Backend backend = Backend.getInstance();
+
         final LocalDateTime dateTop = getLastInitiativeDateUTC();
+
+        Backend backend = Backend.getInstance();
         backend.getAllInitiatives(dateTop, fromCurrentUser, offset, new CallbackCollection<Initiative>() {
             @Override
             public void onSuccess(List<Initiative> initiatives) {
-
                 getActivity().runOnUiThread(() -> {
                     HomeFragment.this.initiatives.addAll(initiatives);
                     populatePostItems();
@@ -149,7 +154,7 @@ public class HomeFragment extends Fragment {
         String mes = String.valueOf(initiative.getDateLocal().getMonthValue());
         String año = String.valueOf(initiative.getDateLocal().getYear());
 
-        return horaConCero +":"+ minutoConCero + " " + dia + "/" + mes + "/" + año;
+        return horaConCero + ":" + minutoConCero + " " + dia + "/" + mes + "/" + año;
     }
 
     private class FilterByCurrentUserListener implements View.OnClickListener {
@@ -157,13 +162,9 @@ public class HomeFragment extends Fragment {
         public void onClick(View v) {
             Switch aSwitch = (Switch) v;
 
-            if (aSwitch.isChecked()) {
-                fromCurrentUser = true;
-            } else {
-                fromCurrentUser = false;
-            }
+            fromCurrentUser = aSwitch.isChecked();
+            offset = 0; // para traer todas
 
-            offset = 0;
             HomeFragment.this.initiatives.clear();
             fetchInitiatives();
         }

--- a/app/src/main/java/com/neiapp/spocan/ui/fragment/ProfileFragment.java
+++ b/app/src/main/java/com/neiapp/spocan/ui/fragment/ProfileFragment.java
@@ -5,15 +5,13 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
 
-import com.neiapp.spocan.Models.User;
+import com.neiapp.spocan.models.User;
 import com.neiapp.spocan.R;
 import com.neiapp.spocan.backend.Backend;
 import com.neiapp.spocan.backend.callback.CallbackInstance;
-import com.neiapp.spocan.backend.rest.HTTPCodes;
 import com.neiapp.spocan.ui.activity.SpocanActivity;
 import com.neiapp.spocan.ui.extra.SpinnerDialog;
 

--- a/app/src/main/res/layout/fragment_home_.xml
+++ b/app/src/main/res/layout/fragment_home_.xml
@@ -90,14 +90,14 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/nunito_light"
-                android:layout_toLeftOf="@id/switch1"
+                android:layout_toLeftOf="@id/own_all_switch"
                 android:textColor="#A0A39F"
                 android:text="@string/switch_desc"/>
 
 
 
         <Switch
-            android:id="@+id/switch1"
+            android:id="@+id/own_all_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:scaleX="0.8"

--- a/app/src/main/res/layout/fragment_home_.xml
+++ b/app/src/main/res/layout/fragment_home_.xml
@@ -12,7 +12,8 @@
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:ignore="MissingConstraints">
+        tools:ignore="MissingConstraints"
+        android:id="@id/scrollView">
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home_.xml
+++ b/app/src/main/res/layout/fragment_home_.xml
@@ -117,12 +117,3 @@
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-<!--  <ImageView
-                android:layout_marginTop="5dp"
-                android:id="@+id/person_home"
-                android:layout_width="40dp"
-                android:layout_height="30dp"
-                android:layout_toLeftOf="@id/switch1"
-                android:src="@drawable/ic_mis_posts"/> -->

--- a/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
+++ b/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
@@ -51,7 +51,7 @@ public class MockedBackendTest {
 
         fakeBackend.createInitiative(initiative_first, call);
         fakeBackend.createInitiative(initiative_second, call);
-        fakeBackend.getAllInitiatives(new CallbackCollection<Initiative>() {
+        fakeBackend.getAllInitiatives(dateFrom, fromCurrentUser, offset, new CallbackCollection<Initiative>() {
             @Override
             public void onSuccess(List<Initiative> collection) {
                 assertEquals(originalSize + 2, MockedBackend.initiative_store.size());

--- a/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
+++ b/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
@@ -24,7 +24,7 @@ public class MockedBackendTest {
         MockedBackend fakeBackend = new MockedBackend();
         int originalSize = MockedBackend.initiative_store.size();
         Initiative created;
-        Initiative initiative = new Initiative("description", "image", false);
+        Initiative initiative = new Initiative("description", "image");
         CallbackVoid callback = new CallbackVoid() {
             @Override
             public void onSuccess() {
@@ -41,8 +41,8 @@ public class MockedBackendTest {
         MockedBackend fakeBackend = new MockedBackend();
         int originalSize = MockedBackend.initiative_store.size();
 
-        Initiative initiative_first = new Initiative("description", "image", false);
-        Initiative initiative_second = new Initiative("description", "image", false);
+        Initiative initiative_first = new Initiative("description", "image");
+        Initiative initiative_second = new Initiative("description", "image");
         CallbackVoid call = new CallbackVoid() {
             @Override
             public void onSuccess() {
@@ -51,7 +51,7 @@ public class MockedBackendTest {
 
         fakeBackend.createInitiative(initiative_first, call);
         fakeBackend.createInitiative(initiative_second, call);
-        fakeBackend.getAllInitiatives(dateFrom, fromCurrentUser, offset, new CallbackCollection<Initiative>() {
+        fakeBackend.getAllInitiatives(null, false, 0, new CallbackCollection<Initiative>() {
             @Override
             public void onSuccess(List<Initiative> collection) {
                 assertEquals(originalSize + 2, MockedBackend.initiative_store.size());

--- a/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
+++ b/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
@@ -1,7 +1,7 @@
 package com.neiapp.spocan.backend;
 
-import com.neiapp.spocan.Models.Initiative;
-import com.neiapp.spocan.Models.UserType;
+import com.neiapp.spocan.models.Initiative;
+import com.neiapp.spocan.models.UserType;
 import com.neiapp.spocan.backend.callback.CallbackCollection;
 import com.neiapp.spocan.backend.callback.CallbackVoid;
 

--- a/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
+++ b/app/src/test/java/com/neiapp/spocan/backend/MockedBackendTest.java
@@ -51,7 +51,7 @@ public class MockedBackendTest {
 
         fakeBackend.createInitiative(initiative_first, call);
         fakeBackend.createInitiative(initiative_second, call);
-        fakeBackend.getAllInitiatives(null, false, 0, new CallbackCollection<Initiative>() {
+        fakeBackend.getAllInitiatives(null, false, new CallbackCollection<Initiative>() {
             @Override
             public void onSuccess(List<Initiative> collection) {
                 assertEquals(originalSize + 2, MockedBackend.initiative_store.size());

--- a/app/src/test/java/com/neiapp/spocan/models/InitiativeTest.java
+++ b/app/src/test/java/com/neiapp/spocan/models/InitiativeTest.java
@@ -1,4 +1,4 @@
- package com.neiapp.spocan.Models;
+ package com.neiapp.spocan.models;
 
  import android.graphics.Bitmap;
 

--- a/app/src/test/java/com/neiapp/spocan/models/InitiativeTest.java
+++ b/app/src/test/java/com/neiapp/spocan/models/InitiativeTest.java
@@ -28,14 +28,12 @@ public class InitiativeTest {
     public void testInitiativeCreation() {
         String  description = "description";
         String  imageBase64 = "imageBase64";
-        boolean isFromCurrentUser = false;
 
-        Initiative initiative = new Initiative(description, imageBase64, isFromCurrentUser);
+        Initiative initiative = new Initiative(description, imageBase64);
         long testNowMillis = LocalDateTime.now(Initiative.UTC).toInstant(ZoneOffset.UTC).toEpochMilli();
 
         assertEquals(description, initiative.getDescription());
         assertEquals(imageBase64, initiative.getImageBase64());
-        assertFalse(initiative.isFromCurrentUser());
         assertNull(initiative.getId());
         assertNull(initiative.getNickname());
 
@@ -49,17 +47,15 @@ public class InitiativeTest {
     public void testInitiativeCreationWithout_IdNorNickname(){
         String  description = "description";
         String  imageBase64 = "imageBase64";
-        boolean isFromCurrentUser = true;
         String nickname = "lolo";
         String _id = "_id";
         LocalDateTime date = LocalDateTime.of(1980, Month.APRIL, 20, 10, 30);
         String dateStrUTC = date.toString();
 
-        Initiative initiative = new Initiative(_id, description, imageBase64, nickname, dateStrUTC, isFromCurrentUser);
+        Initiative initiative = new Initiative(_id, description, imageBase64, nickname, dateStrUTC);
 
         assertEquals(description, initiative.getDescription());
         assertEquals(imageBase64, initiative.getImageBase64());
-        assertTrue(initiative.isFromCurrentUser());
         assertEquals(_id, initiative.getId());
         assertEquals(nickname, initiative.getNickname());
         assertEquals(date, initiative.getDateUTC());
@@ -69,9 +65,8 @@ public class InitiativeTest {
     public void testToJson() throws JSONException, ParseJsonException {
         String  description = "description";
         String  imageBase64 = "imageBase64";
-        boolean isFromCurrentUser = false;
 
-        Initiative initiative = new Initiative(description, imageBase64, isFromCurrentUser);
+        Initiative initiative = new Initiative(description, imageBase64);
 
         String json = initiative.toJson();
 
@@ -95,7 +90,6 @@ public class InitiativeTest {
         jsonInitiative.addProperty("image", "imageBase64");
         jsonInitiative.addProperty("nickname", "nickname");
         jsonInitiative.addProperty("date", dateStrUTC);
-        jsonInitiative.addProperty("from_current_user", "true");
 
         Initiative result = Initiative.convertJson(jsonInitiative.toString());
 
@@ -103,21 +97,18 @@ public class InitiativeTest {
         assertEquals(result.getId(), jsonInitiative.get("_id").getAsString());
         assertEquals(result.getImageBase64(), jsonInitiative.get("image").getAsString());
         assertEquals(result.getNickname(), jsonInitiative.get("nickname").getAsString());
-        assertTrue(result.isFromCurrentUser());
     }
 
     @Test
     public void testBuildInitiativeWithImage() {
         String  description = "description";
-        boolean isFromCurrentUser = true;
         final Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ALPHA_8);
 
-        Initiative initiative = new Initiative(description, bitmap, isFromCurrentUser);
+        Initiative initiative = new Initiative(description, bitmap);
 
         assertNotNull(initiative.getImageBase64());
         assertNotNull(initiative.getImage());
         assertEquals(description, initiative.getDescription());
-        assertTrue(initiative.isFromCurrentUser());
         assertNull(initiative.getId());
         assertNull(initiative.getNickname());
     }
@@ -126,14 +117,13 @@ public class InitiativeTest {
     public void testSettingAndGettingImage() {
         String  description = "description";
         String  imageBase64 = null;
-        boolean isFromCurrentUser = true;
         String nickname = "lolo";
         String _id = "_id";
         LocalDateTime date = LocalDateTime.of(1980, Month.APRIL, 20, 10, 30);
         String dateStrUTC = date.toString();
         final Bitmap bitmap = Bitmap.createBitmap(10, 10, Bitmap.Config.ALPHA_8);
 
-        Initiative initiative = new Initiative(_id, description, imageBase64, nickname, dateStrUTC, isFromCurrentUser);
+        Initiative initiative = new Initiative(_id, description, imageBase64, nickname, dateStrUTC);
 
         initiative.setImage(bitmap);
 
@@ -145,14 +135,13 @@ public class InitiativeTest {
     public void testDateZones() {
         String  description = "description";
         String  imageBase64 = null;
-        boolean isFromCurrentUser = true;
         String nickname = "lolo";
         String _id = "_id";
         LocalDateTime dateUTC = LocalDateTime.of(1980, Month.APRIL, 20, 10, 30);
         String dateStrUTC = dateUTC.toString();
         LocalDateTime zonedBsAsDate = dateUTC.minusHours(Initiative.ZONE_BS_AS_HOURS);
 
-        Initiative initiative = new Initiative(_id, description, imageBase64, nickname, dateStrUTC, isFromCurrentUser);
+        Initiative initiative = new Initiative(_id, description, imageBase64, nickname, dateStrUTC);
 
         assertEquals(dateUTC, initiative.getDateUTC());
         assertEquals(zonedBsAsDate, initiative.getDateLocal());

--- a/app/src/test/java/com/neiapp/spocan/models/UserTest.java
+++ b/app/src/test/java/com/neiapp/spocan/models/UserTest.java
@@ -1,9 +1,8 @@
-package com.neiapp.spocan.Models;
+package com.neiapp.spocan.models;
 
 import com.google.gson.JsonObject;
 import com.neiapp.spocan.backend.ParseJsonException;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/test/java/com/neiapp/spocan/models/UserTypeTest.java
+++ b/app/src/test/java/com/neiapp/spocan/models/UserTypeTest.java
@@ -1,4 +1,4 @@
-package com.neiapp.spocan.Models;
+package com.neiapp.spocan.models;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
- Se expande HomeFragment para pedir iniciativas por batches y también hacer una nueva petición al cambiar a vista "Propias". Incluye listener al llegar al final del ScrollView
- Se agregan parametros a la query en el getAll() de RestClientBackend
- Se eliminan rastros de isFromCurrentUser, ya no es necesario. 
- Se agrega enum InitiativeStatus
- Se agrega la posibilidad de configurar el spinner para que sea transparente y sin mensaje